### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@
         define(['../node-uuid/uuid', '../es6-promise/promise', '../fetch-polyfill/fetch'], factory);
     } else if (typeof exports === 'object') {
         //module.exports = factory(require('b'));
-        module.exports = factory(require('node-uuid'), require('es6-promise'), require('fetch-polyfill'));
+        module.exports = factory(require('uuid'), require('es6-promise'), require('fetch-polyfill'));
     } else {
         // Browser globals (root is window)
         root.utils = factory(root.react);

--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
   },
   "homepage": "https://github.com/deepanag/utils-ccb#readme",
   "devDependencies": {
-    "es6-promise": "^3.1.2",
-    "node-uuid": "^1.4.7"
+    "es6-promise": "^3.1.2"
   },
   "dependencies": {
     "es6-promise": "^3.1.2",
     "fetch-polyfill": "^0.8.2",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.